### PR TITLE
Fixed KeyPathNotFoundError for timers with no tags

### DIFF
--- a/discordWrapper.go
+++ b/discordWrapper.go
@@ -45,7 +45,9 @@ func (w DiscordWrapper) RefreshRichPresenceToggl(t TogglWrapper) {
 	tags := ""
 	if len(timeEntry.tags) != 0 {
 		for _, tag := range timeEntry.tags {
-			tags += "#" + tag + " "
+			if (tag != "") {
+				tags += "#" + tag + " "
+			}
 		}
 	}
 	iconId := timeEntry.tags[rand.Intn(len(timeEntry.tags))]

--- a/discordWrapper.go
+++ b/discordWrapper.go
@@ -1,10 +1,11 @@
 package TogglRichPresence
 
 import (
-	"github.com/hugolgst/rich-go/client"
 	"log"
 	"math/rand"
 	"time"
+
+	"github.com/hugolgst/rich-go/client"
 )
 
 type DiscordWrapper struct {
@@ -39,18 +40,17 @@ func (w DiscordWrapper) SetActivity(description, project string) {
 
 func (w DiscordWrapper) RefreshRichPresenceToggl(t TogglWrapper) {
 	timeEntry := t.CurrentTimer()
-    if (timeEntry.description == "") {
-        return
-    }
+	if timeEntry.description == "" {
+		return
+	}
 	tags := ""
+	var iconId string
 	if len(timeEntry.tags) != 0 {
 		for _, tag := range timeEntry.tags {
-			if (tag != "") {
-				tags += "#" + tag + " "
-			}
+			tags += "#" + tag + " "
 		}
+		iconId = timeEntry.tags[rand.Intn(len(timeEntry.tags))]
 	}
-	iconId := timeEntry.tags[rand.Intn(len(timeEntry.tags))]
 	w.currentActivity = client.Activity{
 		Details:    timeEntry.description,
 		LargeImage: iconId,

--- a/togglReader.go
+++ b/togglReader.go
@@ -105,8 +105,10 @@ func (w TogglWrapper) CurrentTimer() Timer {
 	_, err = jsonparser.ArrayEach(requestString, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		tags = append(tags, string(value))
 	}, "data", "tags")
-	if err != nil {
+	if err != nil && err != jsonparser.KeyPathNotFoundError {
 		log.Fatalf("Error iterating through tags array in JSON of current timer: %s", err)
+	} else if err == jsonparser.KeyPathNotFoundError {
+		tags = append(tags,"")
 	}
 
 	runningTimer := Timer{

--- a/togglReader.go
+++ b/togglReader.go
@@ -101,14 +101,14 @@ func (w TogglWrapper) CurrentTimer() Timer {
 		log.Fatalf("Error parsing time string from time entry: %s", err)
 	}
 
-	tags := make([]string, 0)
+	var tags []string
 	_, err = jsonparser.ArrayEach(requestString, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		tags = append(tags, string(value))
 	}, "data", "tags")
 	if err != nil && err != jsonparser.KeyPathNotFoundError {
 		log.Fatalf("Error iterating through tags array in JSON of current timer: %s", err)
 	} else if err == jsonparser.KeyPathNotFoundError {
-		tags = append(tags,"")
+		tags = nil;
 	}
 
 	runningTimer := Timer{


### PR DESCRIPTION
Sup Matei! I ran into a problem trying to use this on a task/timer with no tags. The JSON parser attempts to look for the `tags` but doesn't find it, so it throws this error:
```
Error iterating through tags array in JSON of current timer: Key path not found
```
My fix simply checks if the error thrown is the specific `KeyPathNotFoundError`, and then adds an empty string to the array of tags as a placeholder (this can be replaced with a special char, idk if toggl allows empty strings as tags). I also modified the Discord Wrapper to not display a `#` if there are no tags.